### PR TITLE
Parse existing tripleo-heat-template to create a new tht and ansible role for ansible-based TripleO deployment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,11 @@ To try out this feature, pass the ``tht_input`` extra parameter to ansible::
 
    ansible-playbook -i defauly.inv start_ansibilisation.yml -e tht_input=/path/to/existing/template
 
+If a ``tht_input`` is passed, the ``<myservice>-container-ansible.yaml`` is put
+in the same directory as the existing template.
+
 TODO
 ----
-
-* Automatically parse the output location for tht from the tht_input var
 * Add kolla config section from existing template
 * Add docker_config section from existing template
 * Detect the deploy_stages from tht input

--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,25 @@ You can override these by modifying the ``default.inv`` file, or by passing
 extra vars to ansible-playbook::
 
    ansible-playbook -i defauly.inv start_ansibilisation.yml -e myservice=someotherservice
+
+Limitations
+-----------
+
+Currently, this tool only supports setting up a bare skeleton, as if for a new
+service, and it is up to the user to port over functionality/logic from the
+existing tripleo heat template.
+Work is in progress on parsing existing THT templates and doing more of the
+set-up work for porting to using ansible for deployment.
+
+To try out this feature, pass the ``tht_input`` extra parameter to ansible::
+
+   ansible-playbook -i defauly.inv start_ansibilisation.yml -e tht_input=/path/to/existing/template
+
+TODO
+----
+
+* Automatically parse the output location for tht from the tht_input var
+* Add kolla config section from existing template
+* Add docker_config section from existing template
+* Detect the deploy_stages from tht input
+* Create the <deploy_stage>.yml tasks from existing sections in THT

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ respectively.
 You can override these by modifying the ``default.inv`` file, or by passing
 extra vars to ansible-playbook::
 
-   ansible-playbook -i defauly.inv start_ansibilisation.yml -e myservice=someotherservice
+   ansible-playbook -i default.inv start_ansibilisation.yml -e myservice=someotherservice
 
 Limitations
 -----------

--- a/README.rst
+++ b/README.rst
@@ -43,4 +43,4 @@ in the same directory as the existing template.
 
 TODO
 ----
-* Add in the param renaming/merging with MyServiceVars
+*

--- a/README.rst
+++ b/README.rst
@@ -43,5 +43,4 @@ in the same directory as the existing template.
 
 TODO
 ----
-* Create the <deploy_stage>.yml tasks from existing sections in THT
 * Add in the param renaming/merging with MyServiceVars

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,5 @@ in the same directory as the existing template.
 
 TODO
 ----
-* Detect the deploy_stages from tht input
 * Create the <deploy_stage>.yml tasks from existing sections in THT
 * Add in the param renaming/merging with MyServiceVars

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,6 @@ in the same directory as the existing template.
 
 TODO
 ----
-* Add kolla config section from existing template
-* Add docker_config section from existing template
 * Detect the deploy_stages from tht input
 * Create the <deploy_stage>.yml tasks from existing sections in THT
+* Add in the param renaming/merging with MyServiceVars

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ set-up work for porting to using ansible for deployment.
 
 To try out this feature, pass the ``tht_input`` extra parameter to ansible::
 
-   ansible-playbook -i defauly.inv start_ansibilisation.yml -e tht_input=/path/to/existing/template
+   ansible-playbook -i default.inv start_ansibilisation.yml -e tht_input=/path/to/existing/template
 
 If a ``tht_input`` is passed, the ``<myservice>-container-ansible.yaml`` is put
 in the same directory as the existing template.

--- a/start_ansibilisation.yml
+++ b/start_ansibilisation.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Make the tripleo_{{ myservice }} role" 
+- name: "Make the tripleo_{{ myservice }} role"
   hosts: localhost
   tasks:
     # Leave this task for now, and parse the vars from elsewhere later

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
       - host_prep_tasks
       - external_deploy_tasks
       - deploy_steps_tasks
+      - upgrade_tasks
       - fast_forward_upgrade_tasks
 
 - name: "Parse existing tht template"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,27 @@
 ---
-- set_fact:
+- name: "Set facts"
+  set_fact:
     tripleo_myservice_dir: "{{ output_dir }}/tripleo_{{ myservice }}/"
-    tht_template_output_dir: "{{output_dir}}/"
+    tht_template_output_dir: "{{ output_dir }}/"
     myservice_titlecase: "{{ myservice|title }}"
     deploy_stages:
       - host_prep_tasks
       - external_deploy_tasks
       - deploy_steps_tasks
       - fast_forward_upgrade_tasks
+    #tht_input: ~/tripleo-ansible-deployment/tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
+    tht_input: ''
 
-- name: "Render the tripleo_{{ myservice}} role."
+- name: "Parse existing tht template"
+  block:
+    - shell: |
+        cat {{ tht_input }}
+      register: heat_template
+    - set_fact:
+        tht: "{{ heat_template.stdout | from_yaml }}"
+  when: tht_input != ''
+
+- name: "Render the tripleo_{{ myservice }} role."
   include_tasks: tripleo_myservice.yml
 
 - name: "Render the {{ myservice }}-container-ansible.yaml template."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,12 @@
       - deploy_steps_tasks
       - upgrade_tasks
       - fast_forward_upgrade_tasks
+      - external_upgrade_tasks
 
 - name: "Parse existing tht template"
   when: "{{ tht_input is defined }}"
   block:
-    - shell: |
+    - command: |
         cat {{ tht_input }}
       register: heat_template
     - set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
       - fast_forward_upgrade_tasks
 
 - name: "Parse existing tht template"
+  when: "{{ tht_input is defined }}"
   block:
     - shell: |
         cat {{ tht_input }}
@@ -18,7 +19,9 @@
     - set_fact:
         tht: "{{ heat_template.stdout | from_yaml }}"
         tht_template_output_dir: "{{ tht_input | dirname }}"
-  when: "{{ tht_input is defined }}"
+    - set_fact:
+        deploy_stages: "{{ tht.outputs.role_data.value | select('match', '.*_tasks')| list }}"
+        puppet_config: "{{ tht.outputs.role_data.value.puppet_config }}"
 
 - name: "Render the tripleo_{{ myservice }} role."
   include_tasks: tripleo_myservice.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,6 @@
       - external_deploy_tasks
       - deploy_steps_tasks
       - fast_forward_upgrade_tasks
-    #tht_input: ~/tripleo-ansible-deployment/tripleo-heat-templates/deployment/metrics/collectd-container-puppet.yaml
-    tht_input: ''
 
 - name: "Parse existing tht template"
   block:
@@ -19,7 +17,8 @@
       register: heat_template
     - set_fact:
         tht: "{{ heat_template.stdout | from_yaml }}"
-  when: tht_input != ''
+        tht_template_output_dir: "{{ tht_input | dirname }}"
+  when: "{{ tht_input is defined }}"
 
 - name: "Render the tripleo_{{ myservice }} role."
   include_tasks: tripleo_myservice.yml

--- a/tasks/tht_myservice.yml
+++ b/tasks/tht_myservice.yml
@@ -3,10 +3,11 @@
   block:
     - set_fact:
         tht_template: "THT/new-myservice-container-ansible.yaml.j2"
-      when: tht_input == ''
+      when: "{{ tht_input is not defined }}"
     - set_fact:
         tht_template: "THT/myservice-container-ansible.yaml.j2"
-      when: tht_input != '' 
+      when: "{{ tht_input is defined }}"
+
 - name: Create {{ myservice }}-container-ansible.yaml template.
   template:
     src: "{{ tht_template }}"

--- a/tasks/tht_myservice.yml
+++ b/tasks/tht_myservice.yml
@@ -1,5 +1,13 @@
 ---
+- name: "Choose template source for {{ myservice }}-container-ansible.yaml"
+  block:
+    - set_fact:
+        tht_template: "THT/new-myservice-container-ansible.yaml.j2"
+      when: tht_input == ''
+    - set_fact:
+        tht_template: "THT/myservice-container-ansible.yaml.j2"
+      when: tht_input != '' 
 - name: Create {{ myservice }}-container-ansible.yaml template.
   template:
-    src: THT/myservice-container-ansible.yaml.j2
+    src: "{{ tht_template }}"
     dest: "{{ tht_template_output_dir }}/{{ myservice }}-container-ansible.yaml"

--- a/tasks/tripleo_myservice.yml
+++ b/tasks/tripleo_myservice.yml
@@ -1,14 +1,22 @@
 ---
 - name: Create the output dir
   file:
-    path: "{{ tripleo_myservice_dir }}/tasks/"
+    path: "{{ tripleo_myservice_dir }}/{{ item }}/"
     state: directory
+  loop:
+    - tasks
+    - defaults
 
 - name: Render main.yml for tripleo_{{ myservice }} role
   template:
     src: tripleo_myservice/tasks/main.yml.j2
     dest: "{{ tripleo_myservice_dir }}/tasks/main.yml"
     force: yes
+
+- name: Add the defaults/main.yml
+  template:
+    src: tripleo_myservice/defaults/main.yml.j2
+    dest: "{{ tripleo_myservice_dir }}/defaults/main.yml"
 
 - name: Render tasks for each deploy_stage
   template:

--- a/tasks/tripleo_myservice.yml
+++ b/tasks/tripleo_myservice.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create the output dir
   file:
-    path: "{{tripleo_myservice_dir }}/tasks/"
+    path: "{{ tripleo_myservice_dir }}/tasks/"
     state: directory
 
 - name: Render main.yml for tripleo_{{ myservice }} role

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -8,7 +8,7 @@ description: Configure {{ myservice }} using ansible
 ###############################################################################
 
 parameters:
-  {{ tht.parameters | to_nice_yaml(width=80, indent=2) | indent(width=2,indentfirst=true) }}
+  {{ tht.parameters | to_nice_yaml(width=80, indent=2) | indent(width=2,indentfirst=false) }}
 
   ##############################################################################
   # The existing collectd parameters will be combined with

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -89,8 +89,6 @@ outputs:
       docker_config:
         {{ tht.outputs.role_data.value.docker_config | to_nice_yaml(width=72, indent=2) | indent(width=8, indentfirst=false) }}
 
-## TODO(efoley): parse the tht.outputs.role_data.value.*_tasks and make a list of deploy_stages
-## Keep this here, but add the existing ansible stuff to the tripleo_{{myservice}} role tasks
 {% for deploy_stage in deploy_stages %}
       {{ deploy_stage }}:
         - name: "{{ myservice_titlecase }} {{ deploy_stage }} tasks"

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -1,10 +1,17 @@
-heat_template_version: rocky
+heat_template_version: {{ tht.heat_template_version }}
 
-description: Configure {{ myservice }} using ansible
+description: >
+  {{ tht.description | indent(width=2, indentfirst=false) }}
 
 ###############################################################################
 # NOTE: Contents of this files are based on
 # https://docs.openstack.org/tripleo-docs/latest/developer/tht_walkthrough/service_template_sections.html#ansible-related-parameters
+###############################################################################
+
+###############################################################################
+# TODO: Check the indentation on each section that's imported from the
+# {{ myservice }}-container-puppet.yaml template
+# There's a known issue with to_nice_yaml, that doesn't indent list elements
 ###############################################################################
 
 parameters:
@@ -29,8 +36,10 @@ parameters:
     type: json
 
 resources:
-  ContainersCommon:
-    type: ../containers-common.yaml
+  #############################################################################
+  # TODO: Check that indentation is correct (list items don't indent)
+  #############################################################################
+  {{ tht.resources | to_nice_yaml(width=80, indent=2) | indent(width=2, indentfirst=false)}}
 
   RoleParametersValue:
     type: OS::Heat::Value
@@ -44,7 +53,7 @@ resources:
           # {{ myservice}}-related parameters, using a new key that will be
           # available in the tripleo_{{myservice }} ansible role.
           #####################################################################
-#  TODO(efoley): add a loop here to add in existing params with a snakecase var#
+          #  TODO(efoley): add a loop here to add in existing params with a snakecase var#
           - legacy_param: { get_param: LegacyParam }
           #####################################################################
           # The last element should be the {{ myservice_titlecase }}Vars, which
@@ -54,16 +63,25 @@ resources:
 
 outputs:
   role_data:
-    description: Role data for the {{ myservice_titlecase }} service
+    description: {{ tht.outputs.role_data.description }}
     value:
       service_name: {{ myservice }}
+      #########################################################################
+      # TODO: Check that indentation is correct
+      #########################################################################
+      # TODO: Check that the output is correct, some heat functional are
+      # called here, and they get formatted with the rest of the yaml
+      #########################################################################
       kolla_config:
-      # TODO: add in existing kolla config from tht.outputs.role_data.value.kolla_config
+        {{ tht.outputs.role_data.value.kolla_config | to_nice_yaml(width=72, indent=2) | indent(width=8, indentfirst=false) }}
+      #########################################################################
+      # TODO: Check that indentation is correct
+      #########################################################################
+      # TODO: Check that the output is correct, some heat functional are
+      # called here, and they get formatted with the rest of the yaml
+      #########################################################################
       docker_config:
-        #######################################################################
-        # TODO: Add in the docker_config section from the original
-        # {{ myservice }}-container-puppet.yaml file
-        #######################################################################
+        {{ tht.outputs.role_data.value.docker_config | to_nice_yaml(width=72, indent=2) | indent(width=8, indentfirst=false) }}
 
 ## TODO(efoley): parse the tht.outputs.role_data.value.*_tasks and make a list of deploy_stages
 ## Keep this here, but add the existing ansible stuff to the tripleo_{{myservice}} role tasks
@@ -75,4 +93,5 @@ outputs:
           vars:
             - deploy_stage: "{{ deploy_stage }}"
             - {get_attr: [RoleParametersValue, value]}
+
 {% endfor %}

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -8,55 +8,18 @@ description: Configure {{ myservice }} using ansible
 ###############################################################################
 
 parameters:
-  # These following parameters are needed by TripleO
-  EndpointMap:
-    default: {}
-    description: Mapping of service endpoint -> protocol. Typically set
-                 via parameter_defaults in the resource registry.
-    type: json
-  ServiceData:
-    default: {}
-    description: Dictionary packing service data
-    type: json
-  ServiceNetMap:
-    default: {}
-    description: Mapping of service_name -> network name. Typically set
-                 via parameter_defaults in the resource registry.  This
-                 mapping overrides those in ServiceNetMapDefaults.
-    type: json
-  DefaultPasswords:
-    default: {}
-    type: json
-  RoleName:
-    default: ''
-    description: Role name on which the service is applied
-    type: string
-  RoleParameters:
-    default: {}
-    description: Parameters specific to the role
-    type: json
-
-  # TODO: remove this comment
-  # These are passed through from THT
-  Container{{ myservice_titlecase }}Image:
-    description: image
-    type: string
-  Container{{ myservice_titlecase }}ConfigImage:
-    description: The container image to use for the {{ myservice }} config_volume
-    type: string
-
-  #############################################################################
-  # TODO: Add in the parameters from your existing heat templates here
-  #############################################################################
-
-  {# TODO: populate this with options pulled from myservice-container-puppet.yaml, if provided #}
+  {{ tht.parameters | to_nice_yaml(width=80, indent=2) | indent(width=2,indentfirst=true) }}
 
   ##############################################################################
-  # The existing collectd parameters should be combined with
-  # {{ myservice_titlecase }}Vars and all marked for deprecation.
-  # They will be accepted for backwards compatibility, but new deployments
-  # should add the vars directly into the {{ myservice_titlecase }}Vars
-  # parameter, which will not require anymore changes in THT to add new params.
+  # The existing collectd parameters will be combined with
+  # {{ myservice_titlecase }}Vars in the RoleParametersValue below. Eventually,
+  # these legacy parameters will be deprecated in favour of passing the
+  # parameters into the {{ myservice_titlecase }}Vars param below.
+  # For backwards compatibility these legacy params will be acceptd, but will
+  # be overwritten by any element passed to {{ myservice_titlecase }}.
+  # New configs should add the vars directly into the
+  # {{ myservice_titlecase }}Var parameter, which will not require anymore
+  # changes in THT to add new params.
   ##############################################################################
   {{ myservice_titlecase }}Vars:
     default: {}
@@ -81,10 +44,11 @@ resources:
           # {{ myservice}}-related parameters, using a new key that will be
           # available in the tripleo_{{myservice }} ansible role.
           #####################################################################
+#  TODO(efoley): add a loop here to add in existing params with a snakecase var#
           - legacy_param: { get_param: LegacyParam }
           #####################################################################
           # The last element should be the {{ myservice_titlecase }}Vars, which
-          # overides any previous deprecated metric.
+          # overides any of the legacy parameters.
           #####################################################################
           - { get_param: {{ myservice_titlecase }}Vars }
 
@@ -94,14 +58,15 @@ outputs:
     value:
       service_name: {{ myservice }}
       kolla_config:
-      # TODO(efoley): Does this need to be pushed to ansible?
-      # Leaving it here should be okay, and it should work as long as the
-      # files are in the right place on the host
+      # TODO: add in existing kolla config from tht.outputs.role_data.value.kolla_config
       docker_config:
         #######################################################################
         # TODO: Add in the docker_config section from the original
         # {{ myservice }}-container-puppet.yaml file
         #######################################################################
+
+## TODO(efoley): parse the tht.outputs.role_data.value.*_tasks and make a list of deploy_stages
+## Keep this here, but add the existing ansible stuff to the tripleo_{{myservice}} role tasks
 {% for deploy_stage in deploy_stages %}
       {{ deploy_stage }}:
         - name: "{{ myservice_titlecase }} {{ deploy_stage }} tasks"

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -1,8 +1,8 @@
+{%- import 'templates/macros.yml' as macros -%}
 heat_template_version: {{ tht.heat_template_version }}
 
 description: >
   {{ tht.description | indent(width=2, indentfirst=false) }}
-
 ###############################################################################
 # NOTE: Contents of this files are based on
 # https://docs.openstack.org/tripleo-docs/latest/developer/tht_walkthrough/service_template_sections.html#ansible-related-parameters
@@ -47,17 +47,23 @@ resources:
       type: json
       value:
         map_merge:
-          - tripleo_role_name: {get_param: RoleName}
           #####################################################################
-          # The first items in this list should be any existing
-          # {{ myservice}}-related parameters, using a new key that will be
-          # available in the tripleo_{{myservice }} ansible role.
+          # The values here will be available in the tripleo_{{ myservice }}
+          # (and the {{ myservice }} ansible role.
           #####################################################################
-          #  TODO(efoley): add a loop here to add in existing params with a snakecase var#
-          - legacy_param: { get_param: LegacyParam }
+          # TODO: Update names as appropriate, consider using tripleo_* as a
+          # prefix for vars that will be used by tripleo_{{ myservice }} role
+          # and {{ myservice }}_* for vars that are intended to be passed
+          # straight through to the ansible_{{ myservice }} role, so that they
+          # can be set and overwritten in the {{ myservice_titlecase }}Vars
+          # param that will be used going forward.
+          #####################################################################
+{% for param in tht.parameters %}
+          - {{ macros.snake_case(param) }}: { get_param: {{ param }} }
+{% endfor %}
           #####################################################################
           # The last element should be the {{ myservice_titlecase }}Vars, which
-          # overides any of the legacy parameters.
+          # overides any of the legacy parameters above.
           #####################################################################
           - { get_param: {{ myservice_titlecase }}Vars }
 

--- a/templates/THT/new-myservice-container-ansible.yaml.j2
+++ b/templates/THT/new-myservice-container-ansible.yaml.j2
@@ -1,0 +1,113 @@
+heat_template_version: rocky
+
+description: Configure {{ myservice }} using ansible
+
+###############################################################################
+# NOTE: Contents of this files are based on
+# https://docs.openstack.org/tripleo-docs/latest/developer/tht_walkthrough/service_template_sections.html#ansible-related-parameters
+###############################################################################
+
+parameters:
+  # These following parameters are needed by TripleO
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  ServiceData:
+    default: {}
+    description: Dictionary packing service data
+    type: json
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+  RoleName:
+    default: ''
+    description: Role name on which the service is applied
+    type: string
+  RoleParameters:
+    default: {}
+    description: Parameters specific to the role
+    type: json
+
+  Container{{ myservice_titlecase }}Image:
+    description: image
+    type: string
+  Container{{ myservice_titlecase }}ConfigImage:
+    description: The container image to use for the {{ myservice }} config_volume
+    type: string
+
+  #############################################################################
+  # TODO: Add in additional parameters here, if you have an existing service
+  # It's recommended to use the {{ myservice_titlecase }}Vars below to pass
+  # in parameters for new ansible-based services.
+  #############################################################################
+
+  {{ myservice_titlecase }}Vars:
+    default: {}
+    description: Hash of {{ myservice }} variables used to configure the {{ myservice }} role.
+    tags:
+      - role_specific
+    type: json
+
+resources:
+  ContainersCommon:
+    type: ../containers-common.yaml
+
+  RoleParametersValue:
+    type: OS::Heat::Value
+    properties:
+      type: json
+      value:
+        map_merge:
+          - tripleo_role_name: {get_param: RoleName}
+          #####################################################################
+          # The first items in this list should be any existing
+          # {{ myservice}}-related parameters, {only if there are
+          # legacy params), using a new key that will be available in the
+          # tripleo_{{myservice }} ansible role.
+          #####################################################################
+          # For example:
+          # - legacy_param: { get_param: LegacyParam }
+          #####################################################################
+          # The last element should be the {{ myservice_titlecase }}Vars, which
+          # overides any previous deprecated metric.
+          #####################################################################
+          - { get_param: {{ myservice_titlecase }}Vars }
+
+outputs:
+  role_data:
+    description: Role data for the {{ myservice_titlecase }} service
+    value:
+      service_name: {{ myservice }}
+      #########################################################################
+      # TODO: Uncomment below and add in your kolla_config section
+      #########################################################################
+      # kolla_config:
+      #########################################################################
+      #########################################################################
+      # TODO: Uncoment below and add in your docker_config
+      #########################################################################
+      # docker_config:
+      #########################################################################
+
+      #########################################################################
+      # For the specified deploy_stages, define an ansible task that will call
+      # the relevant tasks from teh generated tripleo_{{myservice}} role
+      #########################################################################
+
+      {%- for deploy_stage in deploy_stages -%}
+      {{ deploy_stage }}:
+        - name: "{{ myservice_titlecase }} {{ deploy_stage }} tasks"
+          import_role:
+            name: tripleo_{{ myservice }}
+          vars:
+            - deploy_stage: "{{ deploy_stage }}"
+            - {get_attr: [RoleParametersValue, value]}
+      {%- endfor -%}

--- a/templates/macros.yml
+++ b/templates/macros.yml
@@ -1,0 +1,4 @@
+{% macro snake_case(var) %}
+{{ var | regex_replace('([A-Z]+)', '_\\1' ) | lower | regex_replace('^_') }}{% endmacro %}
+
+{# {%  set snake_case = snake_case %} #}

--- a/templates/tripleo_myservice/defaults/main.yml.j2
+++ b/templates/tripleo_myservice/defaults/main.yml.j2
@@ -1,0 +1,7 @@
+---
+###############################################################################
+# TODO: Add the default values in here for any of the converted heat params
+# from tripleo-heat-templates. This serves two purposes: it facilitates
+# testing, and it allows for removal of THT params in the future without
+# affecting the ansible role.
+###############################################################################

--- a/templates/tripleo_myservice/defaults/main.yml.j2
+++ b/templates/tripleo_myservice/defaults/main.yml.j2
@@ -1,3 +1,4 @@
+{%- import 'templates/macros.yml' as macros -%}
 ---
 ###############################################################################
 # TODO: Add the default values in here for any of the converted heat params
@@ -5,3 +6,23 @@
 # testing, and it allows for removal of THT params in the future without
 # affecting the ansible role.
 ###############################################################################
+# TODO: Check for any multi-line strings, these aren't handled by this
+# template
+###############################################################################
+{% if tht_input is defined %}
+{% for param in tht.parameters %}
+{% if tht.parameters[param].default is defined %}
+# Corresponds to {{ param }} in THT
+{% if tht.parameters[param].description is defined %}
+{{ tht.parameters[param].description | wordwrap(79) | comment('plain', prefix='', postfix='') }}
+{%- endif -%}
+{{ macros.snake_case(param) }}: {{ tht.parameters[param].default }}
+
+{% else %}
+# {{ param }} has no default set in THT, so {{ macros.snake_case(param) }}
+# will not be set, but my be passed to this role anyway.
+# {{ macros.snake_case(param) }} : <undefined>
+
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/tripleo_myservice/tasks/deploy_stage.yml.j2
+++ b/templates/tripleo_myservice/tasks/deploy_stage.yml.j2
@@ -1,6 +1,7 @@
 ---
 ###############################################################################
-# TODO: Add the tasks in here for {{ deploy_stage }} deploy stage in
-# tripleo_{{ myservice }} role
+# TODO: Check for incorrectly imported Heat functions e.g. get_param, which is
+# formatted as yaml here, and replace with the right var that was passed to
+# ansible via RoleParametersValue
 ###############################################################################
-
+{{ tht.outputs.role_data.value[deploy_stage] | to_nice_yaml(indent=2) | indent(width=0, indentfirst=false) }}

--- a/templates/tripleo_myservice/tasks/deploy_stage.yml.j2
+++ b/templates/tripleo_myservice/tasks/deploy_stage.yml.j2
@@ -1,7 +1,17 @@
 ---
+{% if tht_input is defined %}
 ###############################################################################
 # TODO: Check for incorrectly imported Heat functions e.g. get_param, which is
 # formatted as yaml here, and replace with the right var that was passed to
 # ansible via RoleParametersValue
 ###############################################################################
 {{ tht.outputs.role_data.value[deploy_stage] | to_nice_yaml(indent=2) | indent(width=0, indentfirst=false) }}
+
+{% else %}
+###############################################################################
+# TODO: Add in the deployment logic for {{ deploy_stage }}.
+###############################################################################
+- name: Pretend to do some actions for {{ deploy_stage }}
+  debug:
+    msg: "This is the {{ deploy_stage }} step."
+{% endif %}

--- a/templates/tripleo_myservice/tasks/main.yml.j2
+++ b/templates/tripleo_myservice/tasks/main.yml.j2
@@ -19,4 +19,4 @@
 ###############################################################################
 
 - name: Include tasks for deploy stage
-  include_tasks: {{ "{{ deploy_stage }}.yml" }}
+  include_tasks: {{ '"{{' }} deploy_stage {{ '}}' }}.yml"


### PR DESCRIPTION
See README for details.

Parses the sections of an existing heat template and populates a tripleo_<service> role and a <service>-container-ansible.yaml heat template. 
This doesn't automate everything, but instructions are given on what steps should be taken to update the outputted files.

This tool assumes that you  have an ansible role to configure your service, and that you will add this role to the appropriate deploy step in tripleo_ansible.