### PR TITLE
Make the THT output pleasing to yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+extends: default
+rules:
+  braces: {max-spaces-inside: 1}
+  line-length: {max: 180}
+  indentation: {indent-sequences: consistent}

--- a/templates/THT/myservice-container-ansible.yaml.j2
+++ b/templates/THT/myservice-container-ansible.yaml.j2
@@ -1,4 +1,5 @@
-{%- import 'templates/macros.yml' as macros -%}
+---
+{% import 'templates/macros.yml' as macros -%}
 heat_template_version: {{ tht.heat_template_version }}
 
 description: >
@@ -32,7 +33,7 @@ parameters:
     default: {}
     description: Hash of {{ myservice }} variables used to configure the {{ myservice }} role.
     tags:
-      - role_specific
+    - role_specific
     type: json
 
 resources:
@@ -47,25 +48,25 @@ resources:
       type: json
       value:
         map_merge:
-          #####################################################################
-          # The values here will be available in the tripleo_{{ myservice }}
-          # (and the {{ myservice }} ansible role.
-          #####################################################################
-          # TODO: Update names as appropriate, consider using tripleo_* as a
-          # prefix for vars that will be used by tripleo_{{ myservice }} role
-          # and {{ myservice }}_* for vars that are intended to be passed
-          # straight through to the ansible_{{ myservice }} role, so that they
-          # can be set and overwritten in the {{ myservice_titlecase }}Vars
-          # param that will be used going forward.
-          #####################################################################
+        #####################################################################
+        # The values here will be available in the tripleo_{{ myservice }}
+        # (and the {{ myservice }} ansible role.
+        #####################################################################
+        # TODO: Update names as appropriate, consider using tripleo_* as a
+        # prefix for vars that will be used by tripleo_{{ myservice }} role
+        # and {{ myservice }}_* for vars that are intended to be passed
+        # straight through to the ansible_{{ myservice }} role, so that they
+        # can be set and overwritten in the {{ myservice_titlecase }}Vars
+        # param that will be used going forward.
+        #####################################################################
 {% for param in tht.parameters %}
-          - {{ macros.snake_case(param) }}: { get_param: {{ param }} }
+        - {{ macros.snake_case(param) }}: { get_param: {{ param }} }
 {% endfor %}
-          #####################################################################
-          # The last element should be the {{ myservice_titlecase }}Vars, which
-          # overides any of the legacy parameters above.
-          #####################################################################
-          - { get_param: {{ myservice_titlecase }}Vars }
+        #####################################################################
+        # The last element should be the {{ myservice_titlecase }}Vars, which
+        # overides any of the legacy parameters above.
+        #####################################################################
+        - { get_param: {{ myservice_titlecase }}Vars }
 
 outputs:
   role_data:
@@ -91,11 +92,11 @@ outputs:
 
 {% for deploy_stage in deploy_stages %}
       {{ deploy_stage }}:
-        - name: "{{ myservice_titlecase }} {{ deploy_stage }} tasks"
-          import_role:
-            name: tripleo_{{ myservice }}
-          vars:
-            - deploy_stage: "{{ deploy_stage }}"
-            - {get_attr: [RoleParametersValue, value]}
+      - name: "{{ myservice_titlecase }} {{ deploy_stage }} tasks"
+        import_role:
+          name: tripleo_{{ myservice }}
+        vars:
+        - deploy_stage: "{{ deploy_stage }}"
+        - {get_attr: [RoleParametersValue, value]}
 
-{% endfor %}
+{%- endfor %}


### PR DESCRIPTION
Was running this again today and figured I'd clean up the THT output a bit while I was learning the details of what's in it.

Before:

```
[csibbitt@laptop tripleo-ansible-conversion-starter (master) ]$ ansible-playbook -i default.inv start_ansibilisation.yml -e tht_input=../tripleo-heat-templates/deployment/metrics/qdr-con
tainer-puppet.yaml -e myservice=qdr -e output_dir=/home/csibbitt/cloudops/ansible/tripleo-ansible-conversion-starter/output
[...]
[csibbitt@laptop tripleo-ansible-conversion-starter (master) ]$ yamllint  ../tripleo-heat-templates/deployment/metrics/qdr-container-ansible.yaml  | wc
     95     800    6108
```

Majority of these were:
`  215:34    error    too many spaces inside braces  (braces)`
`  36:81     error    line too long (94 > 80 characters)  (line-length)`

These I took care of with rules.

I think fixing the braces one would decrease readability [1].
Line lengths aren't coming down without drastically reducing readability by adding unnecessary variables.

The other major change was to make list indenting consistent (via a rule) and opting for the "`-` is an indent" style because that was most common in our templates and lines are already long enough!

After:

```
[csibbitt@laptop tripleo-ansible-conversion-starter (master) ]$ yamllint  ../tripleo-heat-templates/deployment/metrics/qdr-container-ansible.yaml  | wc 
      0       0       0
```

[1] https://github.com/infrawatch/tripleo-ansible-conversion-starter/blob/06f72b492c8af3e7035b443cd72a0f586b47cdf3/templates/THT/myservice-container-ansible.yaml.j2#L68
